### PR TITLE
Move imports into log function

### DIFF
--- a/rerun_loader_tfrecord.py
+++ b/rerun_loader_tfrecord.py
@@ -8,6 +8,8 @@ import os
 
 def log_tb_summary_file(filepath: str) -> None:
     """Log a tensorboard summary file to Rerun."""
+    # We defer importing numpy and summary_iterator since these are very slow
+    # and only needed in the case where we actually have a .tfrecord file
     import numpy as np
     from tensorflow.python.summary.summary_iterator import summary_iterator
     for event in summary_iterator(filepath):

--- a/rerun_loader_tfrecord.py
+++ b/rerun_loader_tfrecord.py
@@ -2,14 +2,14 @@
 """Example of an executable data-loader plugin for the Rerun Viewer for tensorboard files."""
 from __future__ import annotations
 
-import numpy as np
-from tensorflow.python.summary.summary_iterator import summary_iterator
 import rerun as rr  # pip install rerun-sdk
 import argparse
 import os
 
 def log_tb_summary_file(filepath: str) -> None:
     """Log a tensorboard summary file to Rerun."""
+    import numpy as np
+    from tensorflow.python.summary.summary_iterator import summary_iterator
     for event in summary_iterator(filepath):
         if not event.HasField("summary"):
             continue


### PR DESCRIPTION
Moves the numpy and more importantly the slow tensorflow import into the log function. Without this change, the check for unsupported files becomes annoyingly slow. Maybe worth adding a quick note about that to https://www.rerun.io/docs/howto/open-any-file @nikolausWest ?