### PR TITLE
Update to use Scalar instead of TimeSeriesScalar

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy
 tensorflow
-rerun-sdk>=0.12.0
+rerun-sdk>=0.15.0

--- a/rerun_loader_tfrecord.py
+++ b/rerun_loader_tfrecord.py
@@ -26,7 +26,7 @@ def log_tb_summary_file(filepath: str) -> None:
             rr.log(name, rr.ImageEncoded(contents=image_raw))
         elif value.HasField("simple_value"):  # scalar
             value = value.simple_value
-            rr.log(name, rr.TimeSeriesScalar(value))
+            rr.log(name, rr.Scalar(value))
         elif value.HasField("histo"):
             # NOTE this is not sufficiently supported by Rerun yet
             #  see https://github.com/rerun-io/rerun/issues/4764


### PR DESCRIPTION
Replaced call to TimeSeriesScalar with call to Scalar and bumped version requirement to the version in which TimeSeriesScalar was removed.